### PR TITLE
Rebuild with tbb 2021

### DIFF
--- a/.ci_support/win_64_variantall.yaml
+++ b/.ci_support/win_64_variantall.yaml
@@ -14,6 +14,8 @@ occt:
 - 7.8.1
 target_platform:
 - win-64
+tbb_devel:
+- '2021'
 variant:
 - all
 vtk:

--- a/.ci_support/win_64_variantnovtk.yaml
+++ b/.ci_support/win_64_variantnovtk.yaml
@@ -14,6 +14,8 @@ occt:
 - 7.8.1
 target_platform:
 - win-64
+tbb_devel:
+- '2021'
 variant:
 - novtk
 vtk:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -25,7 +25,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,8 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V{{ version.replace(".", "_") }}.tar.gz
   sha256: 151b7a522ba8220aed3009e440246abbaf2ffec42672c37e9390096f7f2c098d
-  # patches:
+  patches:
+    - patches/switch-vtk-freetype-cmake-order.patch
   #   # blobfish
   #   - patches/0001-cmake-Don-t-try-to-write-to-install-directory.-You-k.patch
   #   - patches/0002-GeomPlate_BuildAveragePlane-BasePlan-Don-t-set-yvect.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,7 @@ requirements:
     - freetype
     - libgl-devel                   # [linux]
     - rapidjson
-    - tbb-devel                     # [win]
+    - tbb-devel                     # [win and variant=='all']
     - vtk                           # [variant=='all']
     - xorg-libx11                   # [linux]
     - xorg-libxt                    # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "occt" %}
 {% set version = "7.9.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% set build = build + 100 %}   # [variant == "novtk"]
 {% set build = build + 200 %}   # [variant == "all"]

--- a/recipe/patches/switch-vtk-freetype-cmake-order.patch
+++ b/recipe/patches/switch-vtk-freetype-cmake-order.patch
@@ -1,0 +1,52 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d051f5ccce..391f486aa4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -521,23 +521,6 @@ else()
+   OCCT_CHECK_AND_UNSET ("USE_XLIB")
+ endif()
+ 
+-# FreeType
+-if (CAN_USE_FREETYPE AND USE_FREETYPE)
+-  message (STATUS "Info: FreeType is used by OCCT")
+-  add_definitions (-DHAVE_FREETYPE)
+-  OCCT_ADD_VCPKG_FEATURE ("freetype")
+-  list (APPEND OCCT_3RDPARTY_CMAKE_LIST "adm/cmake/freetype")
+-else()
+-  if (NOT CAN_USE_FREETYPE)
+-    OCCT_CHECK_AND_UNSET ("USE_FREETYPE")
+-  endif()
+-  OCCT_UNSET_VCPKG_FEATURE ("freetype")
+-  OCCT_CHECK_AND_UNSET_GROUP ("3RDPARTY_FREETYPE")
+-  OCCT_CHECK_AND_UNSET ("3RDPARTY_FREETYPE_INCLUDE_DIR_freetype2")
+-  OCCT_CHECK_AND_UNSET ("3RDPARTY_FREETYPE_INCLUDE_DIR_ft2build")
+-  OCCT_CHECK_AND_UNSET ("INSTALL_FREETYPE")
+-endif()
+-
+ # VTK
+ if (USE_VTK)
+   add_definitions (-DHAVE_VTK)
+@@ -555,6 +538,23 @@ else()
+   endif()
+ endif()
+ 
++# FreeType
++if (CAN_USE_FREETYPE AND USE_FREETYPE)
++  message (STATUS "Info: FreeType is used by OCCT")
++  add_definitions (-DHAVE_FREETYPE)
++  OCCT_ADD_VCPKG_FEATURE ("freetype")
++  list (APPEND OCCT_3RDPARTY_CMAKE_LIST "adm/cmake/freetype")
++else()
++  if (NOT CAN_USE_FREETYPE)
++    OCCT_CHECK_AND_UNSET ("USE_FREETYPE")
++  endif()
++  OCCT_UNSET_VCPKG_FEATURE ("freetype")
++  OCCT_CHECK_AND_UNSET_GROUP ("3RDPARTY_FREETYPE")
++  OCCT_CHECK_AND_UNSET ("3RDPARTY_FREETYPE_INCLUDE_DIR_freetype2")
++  OCCT_CHECK_AND_UNSET ("3RDPARTY_FREETYPE_INCLUDE_DIR_ft2build")
++  OCCT_CHECK_AND_UNSET ("INSTALL_FREETYPE")
++endif()
++
+ # FREEIMAGE
+ if (CAN_USE_FREEIMAGE AND USE_FREEIMAGE)
+   add_definitions (-DHAVE_FREEIMAGE)


### PR DESCRIPTION
previous build used tbb 2022 which is higher than current global pinning, casuing trouble when migrating dependants to occt 7.9

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
